### PR TITLE
fix(iOS): Allow notification chain forwarding for non-SFMC push notification

### DIFF
--- a/ios/Classes/SfmcPlugin.m
+++ b/ios/Classes/SfmcPlugin.m
@@ -501,9 +501,16 @@ const int LOG_LENGTH = 800;
 // https://github.com/flutter/flutter/issues/52895
 // Flutter overrides `respondToSelector` and does shady things. There is issue in flutter where `didReceiveRemoteNotification`
 // not getting called on AppDelegate. This is workaround to make sure AppDeleage `didReceiveRemoteNotification` gets called.
-- (BOOL)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-    completionHandler(UIBackgroundFetchResultNoData);
-    return YES;
+- (BOOL)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(
+        UIBackgroundFetchResult result))completionHandler {
+    if (userInfo[@"_sid"] != nil || userInfo[@"_m"] != nil) {
+        // SFMC notification - handle it
+        completionHandler(UIBackgroundFetchResultNoData);
+        return YES;
+    }
+
+    // If not SFMC notification, pass it to next handler
+    return NO;
 }
 
 @end


### PR DESCRIPTION
**Fix iOS notification chain forwarding for non-SFMC push notifications**
**Issue**
The current implementation of `didReceiveRemoteNotification:fetchCompletionHandler:` intercepts all push notifications and completes them immediately with UIBackgroundFetchResultNoData. This blocks the notification chain and prevents other plugins from receiving and processing push notifications unrelated to SFMC.


**Fix**
Modified the implementation to handle notifications containing SFMC-specific identifiers (_sid, _m) and return NO for non-SFMC notifications, allowing them to propagate through the notification chain to other handlers.


**Impact**
SFMC push notifications continue to be handled correctly by the plugin
Other plugins can now properly receive and process their remote push notifications
Fixes compatibility issues with other notification-dependent plugins
Aligns with iOS best practices for plugin notification handling