### PR TITLE
Fix parsing of inbox message custom keys

### DIFF
--- a/lib/inbox_message.dart
+++ b/lib/inbox_message.dart
@@ -44,6 +44,19 @@ class InboxMessage {
       this.messageType});
 
   factory InboxMessage.fromJson(Map<String, dynamic> json) {
+    final customKeyList = (json['keys'] is List) ? json['keys'] as List : null;
+    final parsedKeyEntries = customKeyList
+        ?.whereType<Map>()
+        .map((entry) => switch (entry) {
+              {'key': String key, 'value': String value} =>
+                MapEntry(key, value),
+              _ => null,
+            })
+        .nonNulls;
+    final customKeys = switch(parsedKeyEntries) {
+      Iterable<MapEntry<String, String>>() => Map.fromEntries(parsedKeyEntries),
+      _ => null,
+    };
     return InboxMessage(
       id: json['id'] ?? '',
       subject: json['subject'] ?? '',
@@ -62,8 +75,7 @@ class InboxMessage {
           : null,
       url: json['url'] ?? '',
       custom: json['custom'] ?? '',
-      customKeys:
-          (json['keys'] is Map) ? Map<String, String>.from(json['keys']) : null,
+      customKeys: customKeys,
       deleted: json['deleted'] ?? false,
       read: json['read'] ?? false,
       subtitle: json['subtitle'],

--- a/test/sfmc_test.dart
+++ b/test/sfmc_test.dart
@@ -767,6 +767,90 @@ void main() {
         expect(
             mockPlatform.recentCalledMethod, 'unregisterInboxResponseListener');
       });
+
+      test('fromJson - parses inbox message correctly', () {
+        final json = {
+          'id': '000000000000000000000000000000000000000000',
+          'subject': 'Dummy message',
+          'inboxMessage': 'Inbox message',
+          'messageDeleted': 0,
+          'read': false,
+          'startDateUtc': '1970-01-01 00:00:00',
+          'contentType': 0,
+          'messageHash': '0000000000000000000000000000',
+          'requestId': '00000000-0000-0000-0000-00000000',
+          'deleted': false,
+          'inboxMessageType': 1,
+          'keys': [
+            {
+              'key': 'customKey',
+              'value': 'customValue'
+            },
+          ],
+          'sendDateUtc': '1970-01-01 00:00:01',
+          'statusDirty': 0,
+          'endDateUtc': '1970-01-01 00:00:02',
+          'name': ''
+        };
+        final expected = InboxMessage(
+            id: '000000000000000000000000000000000000000000',
+            title: '',
+            alert: '',
+            custom: '',
+            sound: '',
+            customKeys: {
+              'customKey': 'customValue'
+            },
+            deleted: false,
+            endDateUtc: DateTime.parse('1970-01-01T00:00:02'),
+            read: false,
+            sendDateUtc: DateTime.parse('1970-01-01T00:00:01'),
+            startDateUtc: DateTime.parse('1970-01-01T00:00:00'),
+            subject: 'Dummy message',
+            url: '',
+            media: null,
+            subtitle: null,
+            inboxMessage: 'Inbox message',
+            inboxSubtitle: null,
+            notificationMessage: null,
+            messageType: null,
+        );
+        final cases = {
+          json: expected,
+        };
+
+        cases.forEach((input, expected) {
+          expect(
+            InboxMessage.fromJson(input),
+            isA<InboxMessage>()
+                .having(
+                  (it) => it.id,
+                  "expected id",
+                  expected.id,
+                )
+                .having((it) => it.title, "expected title", expected.title)
+                .having((it) => it.customKeys?['customKey'],
+                    'expected custom key', expected.customKeys?['customKey'])
+                .having((it) => it.customKeys?.length,
+                    'expected custom keys length', expected.customKeys?.length)
+                .having((it) => it.endDateUtc, 'expected end date',
+                    expected.endDateUtc)
+                .having((it) => it.sendDateUtc, 'expected send date',
+                    expected.sendDateUtc)
+                .having((it) => it.startDateUtc, 'expected start date',
+                    expected.startDateUtc)
+                .having((it) => it.read, 'expected read status', expected.read)
+                .having((it) => it.deleted, 'expected deleted status',
+                    expected.deleted)
+                .having(
+                    (it) => it.subject, 'expected subject', expected.subject)
+                .having((it) => it.inboxMessage, 'expected inbox message',
+                    expected.inboxMessage)
+                .having((it) => it.inboxSubtitle, 'expected inbox subtitle',
+                    expected.inboxSubtitle),
+          );
+        });
+      });
     });
   });
 }


### PR DESCRIPTION
There is an issue whereby custom keys on inbox messages are not being parsed correctly in the Dart-side code. The issue manifests itself as the `customKeys` field on an `InboxMessage` always being `null`. This is because the custom keys are sent across the method channel bridge as an array of maps. For example...

```
keys: [
  {
    key: "key1",
    value: "value1"
  },
  {
    key: "key2",
    value: "value2"
  }
]
```

Meanwhile, the Dart code is trying to parse this as a flat key-value map. This PR fixes this by parsing the `keys` field in the JSON as a list and maps each element into a `MapEntry` which is passed into the `InboxMessage` constructor.

I have also added a unit test to assert the behaviour of `fromJson` to catch future regressions although I acknowledge this currently falls short of being fully comprehensive due to my lack of domain knowledge about the Salesforce Marketing Cloud APIs.

As a longer-term fix, I would recommend a refactor using the [pigeon](https://pub.dev/packages/pigeon) package to auto-generate the bridging/method channel code to reduce the likelihood of these errors.