### PR TITLE
Fix locale-dependent inbox date serialization breaking the inbox API

### DIFF
--- a/android/src/main/kotlin/com/salesforce/marketingcloud/sfmc/InboxUtils.kt
+++ b/android/src/main/kotlin/com/salesforce/marketingcloud/sfmc/InboxUtils.kt
@@ -5,12 +5,18 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
 
 class InboxUtils {
     companion object {
         fun Date?.asDateString(): String? {
             return this?.let {
-                val format = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+                // Fixed locale, timezone and pattern so the emitted string is
+                // always ISO-8601 UTC, regardless of the device locale,
+                // calendar or digit set, and matches the iOS plugin output.
+                val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
+                format.timeZone = TimeZone.getTimeZone("UTC")
                 val formattedDate = format.format(it)
                 formattedDate
             }

--- a/ios/Classes/InboxUtility.m
+++ b/ios/Classes/InboxUtility.m
@@ -17,6 +17,10 @@
 }
 
 - (NSString *)convertDictionaryToJSONString:(NSDictionary *)dictionary {
+    if (![NSJSONSerialization isValidJSONObject:dictionary]) {
+        NSLog(@"Error converting dictionary to JSON string: dictionary contains values that cannot be serialized to JSON");
+        return nil;
+    }
     NSError *jsonError;
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dictionary options:NSJSONWritingPrettyPrinted error:&jsonError];
     if (jsonData) {
@@ -27,18 +31,34 @@
     }
 }
 
+// Shared formatter with a fixed locale, timezone and pattern so the emitted
+// string is always ISO-8601 UTC, regardless of the device locale, calendar or
+// 12/24-hour setting (see Apple QA1480), and matches the Android plugin output.
++ (NSDateFormatter *)utcDateFormatter {
+    static NSDateFormatter *dateFormatter;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        dateFormatter = [[NSDateFormatter alloc] init];
+        dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+        dateFormatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
+        dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss'Z'";
+    });
+    return dateFormatter;
+}
+
 - (void)convertDatesInMessage:(NSMutableDictionary *)message {
-    [self convertDateField:@"startDateUtc" inMessage:message];
-    [self convertDateField:@"sendDateUtc" inMessage:message];
-    [self convertDateField:@"endDateUtc" inMessage:message];
+    // Convert every NSDate in the message (not just the known
+    // startDateUtc/sendDateUtc/endDateUtc keys) so a date field added by a
+    // future SDK version can never reach NSJSONSerialization unconverted.
+    for (NSString *field in [message allKeys]) {
+        [self convertDateField:field inMessage:message];
+    }
 }
 
 - (void)convertDateField:(NSString *)field inMessage:(NSMutableDictionary *)message {
     if ([message[field] isKindOfClass:[NSDate class]]) {
         NSDate *date = message[field];
-        NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-        dateFormatter.dateFormat = @"yyyy-MM-dd HH:mm:ss";
-        NSString *dateString = [dateFormatter stringFromDate:date];
+        NSString *dateString = [[InboxUtility utcDateFormatter] stringFromDate:date];
         message[field] = dateString;
     }
 }
@@ -54,7 +74,8 @@
         customObject = @{};
     }
 
-    if ([customObject isKindOfClass:[NSDictionary class]]) {
+    if ([customObject isKindOfClass:[NSDictionary class]] &&
+        [NSJSONSerialization isValidJSONObject:customObject]) {
         NSError *jsonError;
         NSData *jsonData = [NSJSONSerialization dataWithJSONObject:customObject options:NSJSONWritingPrettyPrinted error:&jsonError];
         if (jsonData) {

--- a/lib/inbox_message.dart
+++ b/lib/inbox_message.dart
@@ -53,15 +53,9 @@ class InboxMessage {
       alert: json['alert'] ?? '',
       sound: json['sound'] ?? '',
       media: json['media'] != null ? Media.fromJson(json['media']) : null,
-      startDateUtc: json['startDateUtc'] != null
-          ? DateTime.parse(json['startDateUtc'])
-          : null,
-      endDateUtc: json['endDateUtc'] != null
-          ? DateTime.parse(json['endDateUtc'])
-          : null,
-      sendDateUtc: json['sendDateUtc'] != null
-          ? DateTime.parse(json['sendDateUtc'])
-          : null,
+      startDateUtc: _parseDate(json['startDateUtc']),
+      endDateUtc: _parseDate(json['endDateUtc']),
+      sendDateUtc: _parseDate(json['sendDateUtc']),
       url: json['url'] ?? '',
       custom: json['custom'] ?? '',
       customKeys: customKeys,
@@ -75,6 +69,71 @@ class InboxMessage {
           : null,
       messageType: json['messageType'],
     );
+  }
+
+  /// Leniently parses a date value received from the native SDKs.
+  ///
+  /// Both native bridges now emit ISO-8601 UTC strings
+  /// (`yyyy-MM-dd'T'HH:mm:ss'Z'`), which [DateTime.tryParse] handles directly.
+  /// Older plugin versions emitted locale-dependent strings such as
+  /// `2026-05-02 05:28:00`, `2026-05-02 05:28:00.000` or the 12-hour
+  /// `2026-05-02 3:56:00 AM +0000` form produced by iOS devices with a
+  /// 12-hour clock, so those are tolerated as a fallback. Returns `null`
+  /// instead of throwing when the value cannot be parsed, so a single
+  /// malformed date can never fail an entire message list.
+  static DateTime? _parseDate(dynamic value) {
+    if (value is! String || value.isEmpty) {
+      return null;
+    }
+    final trimmed = value.trim();
+    final parsed = DateTime.tryParse(trimmed);
+    if (parsed != null) {
+      return parsed;
+    }
+    final match = RegExp(
+            r'^(\d{4})-(\d{1,2})-(\d{1,2})[ T](\d{1,2}):(\d{2}):(\d{2})(?:\.(\d+))?(?:\s*([AaPp][Mm]))?(?:\s*(Z|[+-]\d{2}:?\d{2}))?$')
+        .firstMatch(trimmed);
+    if (match == null) {
+      return null;
+    }
+    final year = int.parse(match.group(1)!);
+    final month = int.parse(match.group(2)!);
+    final day = int.parse(match.group(3)!);
+    var hour = int.parse(match.group(4)!);
+    final minute = int.parse(match.group(5)!);
+    final second = int.parse(match.group(6)!);
+    final fraction = match.group(7);
+    final millisecond = fraction != null
+        ? int.parse(fraction.padRight(3, '0').substring(0, 3))
+        : 0;
+    final meridiem = match.group(8);
+    if (meridiem != null) {
+      if (hour < 1 || hour > 12) {
+        return null;
+      }
+      final isPm = meridiem.toLowerCase() == 'pm';
+      if (hour == 12) {
+        hour = isPm ? 12 : 0;
+      } else if (isPm) {
+        hour += 12;
+      }
+    }
+    final offset = match.group(9);
+    if (offset == null) {
+      // No zone designator: keep the legacy behavior of DateTime.parse and
+      // interpret the wall-clock time as local time.
+      return DateTime(year, month, day, hour, minute, second, millisecond);
+    }
+    final utc = DateTime.utc(year, month, day, hour, minute, second, millisecond);
+    if (offset == 'Z') {
+      return utc;
+    }
+    final sign = offset.startsWith('-') ? -1 : 1;
+    final digits = offset.substring(1).replaceAll(':', '');
+    final offsetDuration = Duration(
+        hours: int.parse(digits.substring(0, 2)),
+        minutes: int.parse(digits.substring(2, 4)));
+    return sign == 1 ? utc.subtract(offsetDuration) : utc.add(offsetDuration);
   }
 
   Map<String, dynamic> toJson() {

--- a/lib/inbox_message.dart
+++ b/lib/inbox_message.dart
@@ -71,69 +71,20 @@ class InboxMessage {
     );
   }
 
-  /// Leniently parses a date value received from the native SDKs.
+  /// Parses a date value received from the native SDKs.
   ///
-  /// Both native bridges now emit ISO-8601 UTC strings
-  /// (`yyyy-MM-dd'T'HH:mm:ss'Z'`), which [DateTime.tryParse] handles directly.
-  /// Older plugin versions emitted locale-dependent strings such as
-  /// `2026-05-02 05:28:00`, `2026-05-02 05:28:00.000` or the 12-hour
-  /// `2026-05-02 3:56:00 AM +0000` form produced by iOS devices with a
-  /// 12-hour clock, so those are tolerated as a fallback. Returns `null`
-  /// instead of throwing when the value cannot be parsed, so a single
-  /// malformed date can never fail an entire message list.
+  /// Both native bridges emit ISO-8601 UTC strings, and the legacy 24-hour
+  /// forms (`2026-05-02 05:28:00`, with `.SSS` or a `±hhmm` offset) are also
+  /// valid [DateTime.tryParse] input. Anything else — such as the
+  /// locale-dependent 12-hour strings old plugin versions produced on
+  /// 12-hour-clock devices — returns `null` instead of throwing, so a single
+  /// unparseable date can never fail a message list. Those strings crashed
+  /// the old unguarded `DateTime.parse` anyway, so `null` is no regression.
   static DateTime? _parseDate(dynamic value) {
     if (value is! String || value.isEmpty) {
       return null;
     }
-    final trimmed = value.trim();
-    final parsed = DateTime.tryParse(trimmed);
-    if (parsed != null) {
-      return parsed;
-    }
-    final match = RegExp(
-            r'^(\d{4})-(\d{1,2})-(\d{1,2})[ T](\d{1,2}):(\d{2}):(\d{2})(?:\.(\d+))?(?:\s*([AaPp][Mm]))?(?:\s*(Z|[+-]\d{2}:?\d{2}))?$')
-        .firstMatch(trimmed);
-    if (match == null) {
-      return null;
-    }
-    final year = int.parse(match.group(1)!);
-    final month = int.parse(match.group(2)!);
-    final day = int.parse(match.group(3)!);
-    var hour = int.parse(match.group(4)!);
-    final minute = int.parse(match.group(5)!);
-    final second = int.parse(match.group(6)!);
-    final fraction = match.group(7);
-    final millisecond = fraction != null
-        ? int.parse(fraction.padRight(3, '0').substring(0, 3))
-        : 0;
-    final meridiem = match.group(8);
-    if (meridiem != null) {
-      if (hour < 1 || hour > 12) {
-        return null;
-      }
-      final isPm = meridiem.toLowerCase() == 'pm';
-      if (hour == 12) {
-        hour = isPm ? 12 : 0;
-      } else if (isPm) {
-        hour += 12;
-      }
-    }
-    final offset = match.group(9);
-    if (offset == null) {
-      // No zone designator: keep the legacy behavior of DateTime.parse and
-      // interpret the wall-clock time as local time.
-      return DateTime(year, month, day, hour, minute, second, millisecond);
-    }
-    final utc = DateTime.utc(year, month, day, hour, minute, second, millisecond);
-    if (offset == 'Z') {
-      return utc;
-    }
-    final sign = offset.startsWith('-') ? -1 : 1;
-    final digits = offset.substring(1).replaceAll(':', '');
-    final offsetDuration = Duration(
-        hours: int.parse(digits.substring(0, 2)),
-        minutes: int.parse(digits.substring(2, 4)));
-    return sign == 1 ? utc.subtract(offsetDuration) : utc.add(offsetDuration);
+    return DateTime.tryParse(value.trim());
   }
 
   Map<String, dynamic> toJson() {

--- a/lib/sfmc_method_channel.dart
+++ b/lib/sfmc_method_channel.dart
@@ -261,12 +261,18 @@ class MethodChannelSfmc extends SfmcPlatform {
     if (call.method == 'onInboxMessagesChanged') {
       final List<dynamic> jsonStringList = call.arguments;
       if (jsonStringList.every((element) => element is String)) {
-        final List<InboxMessage> inboxMessages = jsonStringList
-            .where((jsonString) => jsonString != null)
-            .map((jsonString) {
-          final Map<String, dynamic> jsonMap = jsonDecode(jsonString);
-          return InboxMessage.fromJson(jsonMap);
-        }).toList();
+        final List<InboxMessage> inboxMessages = [];
+        for (final jsonString in jsonStringList) {
+          if (jsonString == null) {
+            continue;
+          }
+          try {
+            final Map<String, dynamic> jsonMap = jsonDecode(jsonString);
+            inboxMessages.add(InboxMessage.fromJson(jsonMap));
+          } catch (e) {
+            debugPrint('Skipping inbox message that could not be parsed: $e');
+          }
+        }
         _callbacksById.forEach((listener) {
           if (listener != null) {
             listener(inboxMessages);
@@ -289,10 +295,18 @@ class MethodChannelSfmc extends SfmcPlatform {
   /// @param messages A list of JSON strings (List<String>), where each string represents the data of an inbox message in JSON format.
   ///
   /// Returns a list of InboxMessage objects (List<InboxMessage>).
+  /// Messages that cannot be parsed are skipped so a single malformed
+  /// message does not fail the entire list.
   static List<InboxMessage> _parseMessages(List<String> messages) {
-    return messages.map((jsonString) {
-      final Map<String, dynamic> jsonMap = jsonDecode(jsonString);
-      return InboxMessage.fromJson(jsonMap);
-    }).toList();
+    final List<InboxMessage> parsedMessages = [];
+    for (final jsonString in messages) {
+      try {
+        final Map<String, dynamic> jsonMap = jsonDecode(jsonString);
+        parsedMessages.add(InboxMessage.fromJson(jsonMap));
+      } catch (e) {
+        debugPrint('Skipping inbox message that could not be parsed: $e');
+      }
+    }
+    return parsedMessages;
   }
 }

--- a/test/inbox_message_test.dart
+++ b/test/inbox_message_test.dart
@@ -40,35 +40,13 @@ void main() {
       expect(message.sendDateUtc, DateTime(2026, 5, 2, 5, 28, 0));
     });
 
-    test('parses legacy 12-hour AM format with offset', () {
+    test('applies UTC offsets', () {
       final message = InboxMessage.fromJson(
-          messageJson('1', sendDateUtc: '2026-05-02 3:56:00 AM +0000'));
-      expect(message.sendDateUtc, DateTime.utc(2026, 5, 2, 3, 56, 0));
-    });
-
-    test('parses legacy 12-hour PM format with offset', () {
-      final message = InboxMessage.fromJson(
-          messageJson('1', sendDateUtc: '2026-05-02 3:56:00 PM +0000'));
-      expect(message.sendDateUtc, DateTime.utc(2026, 5, 2, 15, 56, 0));
-    });
-
-    test('parses legacy 12-hour edge cases 12 AM and 12 PM', () {
-      final midnight = InboxMessage.fromJson(
-          messageJson('1', sendDateUtc: '2026-05-02 12:05:00 AM +0000'));
-      expect(midnight.sendDateUtc, DateTime.utc(2026, 5, 2, 0, 5, 0));
-
-      final noon = InboxMessage.fromJson(
-          messageJson('1', sendDateUtc: '2026-05-02 12:05:00 PM +0000'));
-      expect(noon.sendDateUtc, DateTime.utc(2026, 5, 2, 12, 5, 0));
-    });
-
-    test('applies non-zero UTC offsets', () {
-      final message = InboxMessage.fromJson(
-          messageJson('1', sendDateUtc: '2026-05-02 8:56:00 AM +05:30'));
+          messageJson('1', sendDateUtc: '2026-05-02T08:56:00+05:30'));
       expect(message.sendDateUtc, DateTime.utc(2026, 5, 2, 3, 26, 0));
 
       final negative = InboxMessage.fromJson(
-          messageJson('1', sendDateUtc: '2026-05-02 3:56:00 AM -0400'));
+          messageJson('1', sendDateUtc: '2026-05-02T03:56:00-0400'));
       expect(negative.sendDateUtc, DateTime.utc(2026, 5, 2, 7, 56, 0));
     });
 
@@ -80,6 +58,20 @@ void main() {
       final nonLatin = InboxMessage.fromJson(
           messageJson('1', sendDateUtc: '٢٠٢٦-٠٥-٠٢ ٠٥:٢٨:٠٠'));
       expect(nonLatin.sendDateUtc, null);
+    });
+
+    test('returns null for locale-dependent legacy 12-hour strings', () {
+      // These crashed the old unguarded DateTime.parse, so null is the
+      // intended (non-regressing) outcome rather than a best-effort rescue.
+      for (final legacy in [
+        '2026-05-02 3:56:00 AM +0000',
+        '2026-05-02 3:56:00 PM +0000',
+        '2026-05-02 12:05:00 AM +0000',
+        '2026-05-02 午前3:56:00',
+      ]) {
+        expect(InboxMessage.fromJson(messageJson('1', sendDateUtc: legacy))
+            .sendDateUtc, null, reason: legacy);
+      }
     });
 
     test('returns null for non-string and empty values', () {
@@ -94,7 +86,7 @@ void main() {
       final json = messageJson('1');
       json['startDateUtc'] = '2026-05-01T00:00:00Z';
       json['sendDateUtc'] = '2026-05-02T05:28:00Z';
-      json['endDateUtc'] = '2026-05-03 3:56:00 AM +0000';
+      json['endDateUtc'] = '2026-05-03T03:56:00Z';
       final message = InboxMessage.fromJson(json);
       expect(message.startDateUtc, DateTime.utc(2026, 5, 1));
       expect(message.sendDateUtc, DateTime.utc(2026, 5, 2, 5, 28, 0));
@@ -147,7 +139,7 @@ void main() {
       final messages = await platform.getMessages();
       expect(messages.length, 2);
       expect(messages[0].id, 'legacy');
-      expect(messages[0].sendDateUtc, DateTime.utc(2026, 5, 2, 3, 56, 0));
+      expect(messages[0].sendDateUtc, null);
       expect(messages[1].id, 'broken');
       expect(messages[1].sendDateUtc, null);
     });

--- a/test/inbox_message_test.dart
+++ b/test/inbox_message_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sfmc/inbox_message.dart';
+import 'package:sfmc/sfmc_method_channel.dart';
+import 'dart:convert';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Map<String, dynamic> messageJson(String id, {dynamic sendDateUtc}) {
+    return {
+      'id': id,
+      'subject': 'Subject $id',
+      'title': 'Title $id',
+      'alert': 'Alert $id',
+      'deleted': false,
+      'read': false,
+      'url': 'https://example.com/$id',
+      if (sendDateUtc != null) 'sendDateUtc': sendDateUtc,
+    };
+  }
+
+  group('InboxMessage.fromJson date parsing', () {
+    test('parses ISO-8601 UTC format emitted by both native bridges', () {
+      final message = InboxMessage.fromJson(
+          messageJson('1', sendDateUtc: '2026-05-02T05:28:00Z'));
+      expect(message.sendDateUtc, DateTime.utc(2026, 5, 2, 5, 28, 0));
+      expect(message.sendDateUtc!.isUtc, true);
+    });
+
+    test('parses legacy space-separated format without milliseconds', () {
+      final message = InboxMessage.fromJson(
+          messageJson('1', sendDateUtc: '2026-05-02 05:28:00'));
+      expect(message.sendDateUtc, DateTime(2026, 5, 2, 5, 28, 0));
+    });
+
+    test('parses legacy space-separated format with milliseconds', () {
+      final message = InboxMessage.fromJson(
+          messageJson('1', sendDateUtc: '2026-05-02 05:28:00.000'));
+      expect(message.sendDateUtc, DateTime(2026, 5, 2, 5, 28, 0));
+    });
+
+    test('parses legacy 12-hour AM format with offset', () {
+      final message = InboxMessage.fromJson(
+          messageJson('1', sendDateUtc: '2026-05-02 3:56:00 AM +0000'));
+      expect(message.sendDateUtc, DateTime.utc(2026, 5, 2, 3, 56, 0));
+    });
+
+    test('parses legacy 12-hour PM format with offset', () {
+      final message = InboxMessage.fromJson(
+          messageJson('1', sendDateUtc: '2026-05-02 3:56:00 PM +0000'));
+      expect(message.sendDateUtc, DateTime.utc(2026, 5, 2, 15, 56, 0));
+    });
+
+    test('parses legacy 12-hour edge cases 12 AM and 12 PM', () {
+      final midnight = InboxMessage.fromJson(
+          messageJson('1', sendDateUtc: '2026-05-02 12:05:00 AM +0000'));
+      expect(midnight.sendDateUtc, DateTime.utc(2026, 5, 2, 0, 5, 0));
+
+      final noon = InboxMessage.fromJson(
+          messageJson('1', sendDateUtc: '2026-05-02 12:05:00 PM +0000'));
+      expect(noon.sendDateUtc, DateTime.utc(2026, 5, 2, 12, 5, 0));
+    });
+
+    test('applies non-zero UTC offsets', () {
+      final message = InboxMessage.fromJson(
+          messageJson('1', sendDateUtc: '2026-05-02 8:56:00 AM +05:30'));
+      expect(message.sendDateUtc, DateTime.utc(2026, 5, 2, 3, 26, 0));
+
+      final negative = InboxMessage.fromJson(
+          messageJson('1', sendDateUtc: '2026-05-02 3:56:00 AM -0400'));
+      expect(negative.sendDateUtc, DateTime.utc(2026, 5, 2, 7, 56, 0));
+    });
+
+    test('returns null instead of throwing for unparseable dates', () {
+      final message = InboxMessage.fromJson(
+          messageJson('1', sendDateUtc: 'not a date'));
+      expect(message.sendDateUtc, null);
+
+      final nonLatin = InboxMessage.fromJson(
+          messageJson('1', sendDateUtc: '٢٠٢٦-٠٥-٠٢ ٠٥:٢٨:٠٠'));
+      expect(nonLatin.sendDateUtc, null);
+    });
+
+    test('returns null for non-string and empty values', () {
+      expect(InboxMessage.fromJson(messageJson('1', sendDateUtc: 12345))
+          .sendDateUtc, null);
+      expect(InboxMessage.fromJson(messageJson('1', sendDateUtc: ''))
+          .sendDateUtc, null);
+      expect(InboxMessage.fromJson(messageJson('1')).sendDateUtc, null);
+    });
+
+    test('parses all three date fields', () {
+      final json = messageJson('1');
+      json['startDateUtc'] = '2026-05-01T00:00:00Z';
+      json['sendDateUtc'] = '2026-05-02T05:28:00Z';
+      json['endDateUtc'] = '2026-05-03 3:56:00 AM +0000';
+      final message = InboxMessage.fromJson(json);
+      expect(message.startDateUtc, DateTime.utc(2026, 5, 1));
+      expect(message.sendDateUtc, DateTime.utc(2026, 5, 2, 5, 28, 0));
+      expect(message.endDateUtc, DateTime.utc(2026, 5, 3, 3, 56, 0));
+    });
+  });
+
+  group('Malformed inbox messages are skipped', () {
+    MethodChannelSfmc platform = MethodChannelSfmc();
+    const MethodChannel channel = MethodChannel('sfmc');
+
+    final String goodMessage = jsonEncode(
+        messageJson('good', sendDateUtc: '2026-05-02T05:28:00Z'));
+    const String malformedMessage = '{"id": "bad", not valid json';
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    test('getMessages skips a malformed message instead of failing', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        if (methodCall.method == 'getMessages') {
+          return [malformedMessage, goodMessage];
+        }
+        return null;
+      });
+
+      final messages = await platform.getMessages();
+      expect(messages.length, 1);
+      expect(messages[0].id, 'good');
+      expect(messages[0].sendDateUtc, DateTime.utc(2026, 5, 2, 5, 28, 0));
+    });
+
+    test('message with an unparseable date is kept with a null date',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        if (methodCall.method == 'getMessages') {
+          return [
+            jsonEncode(messageJson('legacy',
+                sendDateUtc: '2026-05-02 3:56:00 AM +0000')),
+            jsonEncode(messageJson('broken', sendDateUtc: 'not a date')),
+          ];
+        }
+        return null;
+      });
+
+      final messages = await platform.getMessages();
+      expect(messages.length, 2);
+      expect(messages[0].id, 'legacy');
+      expect(messages[0].sendDateUtc, DateTime.utc(2026, 5, 2, 3, 56, 0));
+      expect(messages[1].id, 'broken');
+      expect(messages[1].sendDateUtc, null);
+    });
+
+    test('onInboxMessagesChanged delivers remaining messages when one is malformed',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        return null;
+      });
+
+      List<InboxMessage>? receivedMessages;
+      listener(List<InboxMessage> messages) {
+        receivedMessages = messages;
+      }
+
+      await platform.registerInboxResponseListener(listener);
+
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+        'sfmc',
+        const StandardMethodCodec().encodeMethodCall(
+            MethodCall('onInboxMessagesChanged',
+                [malformedMessage, goodMessage])),
+        (ByteData? data) {},
+      );
+
+      expect(receivedMessages, isNotNull);
+      expect(receivedMessages!.length, 1);
+      expect(receivedMessages![0].id, 'good');
+
+      await platform.unregisterInboxResponseListener(listener);
+    });
+  });
+}


### PR DESCRIPTION
The inbox date formatters on both platforms depend on the device locale and timezone. On an iPhone set to a 12-hour clock the formatter emits `2026-05-02 3:56:00 AM` (Apple QA1480), which `DateTime.parse` rejects. Parsing runs in a single `.map()` over the whole list, so one bad date makes `getMessages()` and the other inbox getters throw, and inbox listeners silently stop firing. Android has the same defect with non-Latin-digit locales (ar, th, ...), and its `*Utc` fields actually carry local wall time.

Both bridges now emit `yyyy-MM-dd'T'HH:mm:ss'Z'` with a fixed locale and UTC, and the Dart side parses leniently (keeping a fallback for the old formats) and skips a malformed message instead of failing the whole list.

Related to #7, which fixes the iOS formatter the same way but doesn't touch the Android side or the all-or-nothing parsing. This also makes the `endDateUtc` fix from #4 future-proof: every NSDate in the payload gets converted, and NSJSONSerialization is guarded so an unconverted value can no longer crash the app.

11 of the new tests fail on main as it is today.
