### PR TITLE
Fix TypeError when an Android inbox message carries a notification payload

### DIFF
--- a/android/src/main/kotlin/com/salesforce/marketingcloud/sfmc/InboxUtils.kt
+++ b/android/src/main/kotlin/com/salesforce/marketingcloud/sfmc/InboxUtils.kt
@@ -43,7 +43,7 @@ class InboxUtils {
                 mediaAltText?.let { put("mediaAltText", it) }
                 customKeys.asKeyValueJsonArray()?.let { put("customKeys", it) }
                 custom?.let { put("custom", it) }
-                payload?.let { put("payload", mapToJson(it)) }
+                payload?.let { put("payload", JSONObject(it)) }
                 // richFeatures?.let { put("richFeatures", it.toJson()) }
              }
         }
@@ -82,10 +82,6 @@ class InboxUtils {
         fun inboxMessagesToString(messages: List<InboxMessage>): List<String> {
             var messageString = messages.mapNotNull { it.toJson().toString() }
             return messageString
-        }
-
-        fun mapToJson(map: Map<String, String>): String {
-            return JSONObject(map).toString()
         }
     }
 }

--- a/lib/notification_message.dart
+++ b/lib/notification_message.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'package:flutter/foundation.dart';
 import 'custom_keys_parser.dart';
 
 class NotificationMessage {
@@ -37,7 +36,6 @@ class NotificationMessage {
 
   factory NotificationMessage.fromJson(Map<String, dynamic> json) {
     final customKeys = CustomKeysParser.parseCustomKeys(json['customKeys']);
-    debugPrint(json.toString());
     return NotificationMessage(
       id: json['id'] ?? '',
       alert: json['alert'] ?? '',
@@ -52,10 +50,19 @@ class NotificationMessage {
       mediaAltText: json['mediaAltText'],
       customKeys: customKeys,
       custom: json['custom'],
-      payload: json['payload'] != null
-          ? Map<String, String>.from(json['payload'])
-          : null,
+      payload: _parsePayload(json['payload']),
     );
+  }
+
+  static Map<String, String>? _parsePayload(dynamic payload) {
+    if (payload is String) {
+      payload = jsonDecode(payload);
+    }
+    if (payload is Map) {
+      return payload
+          .map((key, value) => MapEntry(key.toString(), value.toString()));
+    }
+    return null;
   }
 
   Map<String, dynamic> toJson() {

--- a/test/notification_message_test.dart
+++ b/test/notification_message_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sfmc/notification_message.dart';
+import 'dart:convert';
+
+void main() {
+  Map<String, dynamic> notificationJson({dynamic payload}) => {
+        'id': 'notification_1',
+        'alert': 'Test alert',
+        'type': 'OTHER',
+        'trigger': 'PUSH',
+        if (payload != null) 'payload': payload,
+      };
+
+  group('NotificationMessage payload parsing', () {
+    test('accepts payload as a Map (current Android wire format)', () {
+      final message = NotificationMessage.fromJson(
+          notificationJson(payload: {'_m': 'message_id', 'key': 'value'}));
+      expect(message.payload, {'_m': 'message_id', 'key': 'value'});
+    });
+
+    test('accepts payload as a JSON-encoded String (older Android wire format)',
+        () {
+      final message = NotificationMessage.fromJson(notificationJson(
+          payload: jsonEncode({'_m': 'message_id', 'key': 'value'})));
+      expect(message.payload, {'_m': 'message_id', 'key': 'value'});
+    });
+
+    test('payload is null when absent', () {
+      final message = NotificationMessage.fromJson(notificationJson());
+      expect(message.payload, isNull);
+    });
+  });
+}

--- a/test/sfmc_method_channel_test.dart
+++ b/test/sfmc_method_channel_test.dart
@@ -651,6 +651,50 @@ void main() {
       expect(messages[0].deleted, true);
     });
 
+    test('getMessages parses notificationMessage payload for both wire shapes',
+        () async {
+      final List<String> mockMsgsWithPayload = [
+        jsonEncode({
+          "id": "10",
+          "deleted": false,
+          "read": false,
+          "notificationMessage": {
+            "id": "n10",
+            "alert": "Alert 10",
+            "type": "OTHER",
+            "trigger": "PUSH",
+            "payload": {"_m": "m10", "key": "value"}
+          }
+        }),
+        jsonEncode({
+          "id": "11",
+          "deleted": false,
+          "read": false,
+          "notificationMessage": {
+            "id": "n11",
+            "alert": "Alert 11",
+            "type": "OTHER",
+            "trigger": "PUSH",
+            "payload": jsonEncode({"_m": "m11", "key": "value"})
+          }
+        }),
+      ];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        if (methodCall.method == 'getMessages') {
+          return mockMsgsWithPayload;
+        }
+        return null;
+      });
+
+      final messages = await platform.getMessages();
+      expect(messages.length, 2);
+      expect(messages[0].notificationMessage?.payload,
+          {"_m": "m10", "key": "value"});
+      expect(messages[1].notificationMessage?.payload,
+          {"_m": "m11", "key": "value"});
+    });
+
     test('setMessageRead', () async {
       bool methodCalled = false;
       const String messageId = "testMessageReadId";


### PR DESCRIPTION
On Android, `InboxUtils` serializes `notificationMessage.payload` with `JSONObject(map).toString()`, so Dart receives a JSON string where `NotificationMessage.fromJson` expects a map and throws `type 'String' is not a subtype of type 'Map<dynamic, dynamic>'`. A single alert+inbox push in the inbox is enough to break `getMessages()` and the other getters entirely. iOS is unaffected (it doesn't emit `notificationMessage`).

The payload is now put as a `JSONObject`, and the Dart side accepts both shapes so apps aren't stuck if the native and Dart versions are briefly out of sync. Also removed a leftover `debugPrint` that dumped the full notification payload on every parse.
