### PR TITLE
iOS: complete the FlutterResult in inbox listener registration, fix double reply in setAttribute

### DIFF
--- a/ios/Classes/SfmcPlugin.m
+++ b/ios/Classes/SfmcPlugin.m
@@ -105,7 +105,6 @@ const int LOG_LENGTH = 800;
         NSString *key = args[@"key"];
         NSString *value = args[@"value"];
         [self setAttributeWithKey:key value:value result:result];
-        result(nil);
     } else if ([@"clearAttribute" isEqualToString:call.method]) {
         NSString *key = call.arguments[@"key"];
         [self clearAttributeWithKey:key result:result];
@@ -154,8 +153,10 @@ const int LOG_LENGTH = 800;
         [self refreshInbox:result];
     } else if ([@"registerInboxResponseListener" isEqualToString:call.method]) {
         [self registerListeners];
+        result(nil);
     } else if ([@"unregisterInboxResponseListener" isEqualToString:call.method]) {
         [self unregisterListeners];
+        result(nil);
     } else {
         result(FlutterMethodNotImplemented);
     }


### PR DESCRIPTION
Two small method-channel contract issues in `SfmcPlugin.m`:

`registerInboxResponseListener` / `unregisterInboxResponseListener` never invoke the result block, so on iOS `await SFMCSdk.registerInboxResponseListener(...)` simply never resolves. Easy to hit if you await it during app init - there's no error, the code after the await just never runs. Android replies with `result.success(null)`.

`setAttribute` has the opposite problem: it replies inside the `requestPushSdk` completion and then again synchronously right after.

Three-line fix, following the pattern of the other handler branches.
