### PR TITLE
refreshInbox never invokes the callback it takes

### DIFF
--- a/lib/sfmc_method_channel.dart
+++ b/lib/sfmc_method_channel.dart
@@ -222,7 +222,10 @@ class MethodChannelSfmc extends SfmcPlatform {
 
   @override
   Future<bool> refreshInbox(InboxRefreshListener callback) async {
-    return await methodChannel.invokeMethod('refreshInbox');
+    final bool successful =
+        await methodChannel.invokeMethod<bool?>('refreshInbox') ?? false;
+    callback(successful);
+    return successful;
   }
 
   @override

--- a/test/sfmc_method_channel_test.dart
+++ b/test/sfmc_method_channel_test.dart
@@ -727,8 +727,47 @@ void main() {
       expect(methodCalled, true);
     });
 
-    test('refreshInbox', () async {
-      expect(await platform.isPiAnalyticsEnabled(), true);
+    test('refreshInbox invokes callback with true when refresh succeeds',
+        () async {
+      bool? callbackResult;
+      final result = await platform.refreshInbox((successful) {
+        callbackResult = successful;
+      });
+      expect(result, true);
+      expect(callbackResult, true);
+    });
+
+    test('refreshInbox invokes callback with false when refresh fails',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        if (methodCall.method == 'refreshInbox') {
+          return false;
+        }
+        return null;
+      });
+
+      bool? callbackResult;
+      final result = await platform.refreshInbox((successful) {
+        callbackResult = successful;
+      });
+      expect(result, false);
+      expect(callbackResult, false);
+    });
+
+    test('refreshInbox invokes callback with false when native returns null',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        return null;
+      });
+
+      bool? callbackResult;
+      final result = await platform.refreshInbox((successful) {
+        callbackResult = successful;
+      });
+      expect(result, false);
+      expect(callbackResult, false);
     });
 
     responseObject(response) {}


### PR DESCRIPTION
`SFMCSdk.refreshInbox(callback)` requires an `InboxRefreshListener`, but the method channel implementation never calls it - the outcome was only visible on the returned Future. The callback now gets the native result (null coerced to false); the public signature is unchanged.

While here: the existing `refreshInbox` unit test was a copy-paste that asserted `isPiAnalyticsEnabled()` and never called `refreshInbox`. Replaced it with tests that do.
