### PR TITLE
Fix example app build on current Flutter

### DIFF
--- a/Android.md
+++ b/Android.md
@@ -98,7 +98,7 @@ apply plugin: 'com.google.gms.google-services'
 
 ## 7. Update `MainApplication.kt`
 
-> If `MainApplication.kt` is not there in your app create `MainApplication` extending `FlutterApplication` class and also update the `AndroidManifest.xml`.
+> If `MainApplication.kt` is not there in your app create `MainApplication` extending `Application` class and also update the `AndroidManifest.xml`.
 
 ```xml
 // add ".MainApplication" entry in main/AndroidManifest.xml
@@ -120,9 +120,9 @@ import com.salesforce.marketingcloud.notifications.NotificationCustomizationOpti
 import com.salesforce.marketingcloud.sfmcsdk.InitializationStatus
 import com.salesforce.marketingcloud.sfmcsdk.SFMCSdk
 import com.salesforce.marketingcloud.sfmcsdk.SFMCSdkModuleConfig
-import io.flutter.app.FlutterApplication
+import android.app.Application
 
-class MainApplication : FlutterApplication() {
+class MainApplication : Application() {
 
     //Update onCreate
     override fun onCreate() {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/example/android/app/src/main/kotlin/com/salesforce/marketingcloud/sfmc_example/MainApplication.kt
+++ b/example/android/app/src/main/kotlin/com/salesforce/marketingcloud/sfmc_example/MainApplication.kt
@@ -27,6 +27,7 @@
 
 package com.salesforce.marketingcloud.sfmc_example
 
+import android.app.Application
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
@@ -41,10 +42,9 @@ import com.salesforce.marketingcloud.sfmcsdk.InitializationStatus
 import com.salesforce.marketingcloud.sfmcsdk.SFMCSdk
 import com.salesforce.marketingcloud.sfmcsdk.SFMCSdkModuleConfig
 import com.salesforce.marketingcloud.UrlHandler
-import io.flutter.app.FlutterApplication
 import java.util.Random
 
-class MainApplication : FlutterApplication() {
+class MainApplication : Application() {
     companion object {
         private const val TAG = "~&SFMC Example App"
     }

--- a/example/ios/Runner/AppDelegate.m
+++ b/example/ios/Runner/AppDelegate.m
@@ -38,7 +38,7 @@
     PushConfigBuilder *pushConfigBuilder = [[PushConfigBuilder alloc] initWithAppId:@"{MC_APP_ID}"];
     [pushConfigBuilder setAccessToken:@"{MC_ACCESS_TOKEN}"];
     [pushConfigBuilder setMarketingCloudServerUrl:[NSURL URLWithString:@"{MC_APP_SERVER_URL}"]];
-    [pushConfigBuilder setMid:@"MC_MID"];
+    [pushConfigBuilder setMid:@"{MC_MID}"];
     [pushConfigBuilder setAnalyticsEnabled:YES];
     [pushConfigBuilder setInboxEnabled:YES];
     [SFMCSdk initializeSdk:[[[SFMCSdkConfigBuilder new] setPushWithConfig:[pushConfigBuilder build] onCompletion:^(SFMCSdkOperationResult result) {

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -1,27 +1,51 @@
-// This is a basic Flutter widget test.
+// This is a basic Flutter widget test for the SFMC example app.
 //
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
+// It mocks the plugin's method channel so the example app can be
+// built inside the test binding without a real platform implementation,
+// then verifies that the demo UI renders without throwing.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:sfmc_example/main.dart';
 
 void main() {
-  testWidgets('Verify Platform version', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const MethodChannel channel = MethodChannel('sfmc');
 
-    // Verify that platform version is retrieved.
-    expect(
-      find.byWidgetPredicate(
-        (Widget widget) => widget is Text &&
-                           widget.data!.startsWith('Running on:'),
-      ),
-      findsOneWidget,
+  setUp(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      channel,
+      (MethodCall methodCall) async {
+        switch (methodCall.method) {
+          case 'isAnalyticsEnabled':
+          case 'isPiAnalyticsEnabled':
+            return false;
+          default:
+            return null;
+        }
+      },
     );
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  testWidgets('Example app builds and shows the SFMC demo UI',
+      (WidgetTester tester) async {
+    // Build our app and trigger a frame.
+    await tester.pumpWidget(const MaterialApp(home: MyApp()));
+    await tester.pumpAndSettle();
+
+    // Verify the app rendered without throwing.
+    expect(tester.takeException(), isNull);
+
+    // Verify the SFMC demo UI is shown.
+    expect(find.text('SFMC Flutter SDK Example'), findsOneWidget);
+    expect(find.text('GET SYSTEM TOKEN'), findsOneWidget);
   });
 }

--- a/iOS_objc.md
+++ b/iOS_objc.md
@@ -63,7 +63,7 @@ Navigate to the `AppDelegate.m` and update the file.
     PushConfigBuilder *pushConfigBuilder = [[PushConfigBuilder alloc] initWithAppId:@"{MC_APP_ID}"];
     [pushConfigBuilder setAccessToken:@"{MC_ACCESS_TOKEN}"];
     [pushConfigBuilder setMarketingCloudServerUrl:[NSURL URLWithString:@"{MC_APP_SERVER_URL}"]];
-    [pushConfigBuilder setMid:@"MC_MID"];
+    [pushConfigBuilder setMid:@"{MC_MID}"];
     [pushConfigBuilder setAnalyticsEnabled:YES];
 
     // Once you've created the mobile push configuration, intialize the SDK.


### PR DESCRIPTION
Gets the example app (and the plugin's own gradle wrapper) working on current tooling:

- `io.flutter.app.FlutterApplication` was removed in Flutter 3.29, so the example no longer compiles. `MainApplication` now extends `android.app.Application`; the snippet in Android.md is updated to match.
- The MID placeholder in the example `AppDelegate.m` was missing its braces (`MC_MID` instead of `{MC_MID}`), so a brace-targeted find/replace leaves the literal string behind. Same fix in iOS_objc.md.
- `example/test/widget_test.dart` was still the counter-app template and always failed under `flutter test`. Replaced with a smoke test that pumps the real app with the method channel mocked.
- The plugin's own gradle wrapper was 8.0 while android/build.gradle declares AGP 8.6.1, which needs Gradle 8.7+. Bumped to 8.9 to match the example.
