### PR TITLE
Analyzer cleanup, drop unused provider dependency, cover inbox write APIs with tests

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -215,14 +215,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.2"
-  provider:
-    dependency: transitive
-    description:
-      name: provider
-      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.2"
   sfmc:
     dependency: "direct main"
     description:

--- a/lib/events.dart
+++ b/lib/events.dart
@@ -36,8 +36,6 @@ extension EventCategoryExtension on EventCategory {
         return 'identity';
       case EventCategory.system:
         return 'system';
-      default:
-        return '';
     }
   }
 }
@@ -88,8 +86,6 @@ extension CartEventTypeExtension on CartEventType {
         return "Remove From Cart";
       case CartEventType.replace:
         return "Replace Cart";
-      default:
-        return "";
     }
   }
 }
@@ -151,8 +147,6 @@ extension CatalogObjectEventNameExtension on CatalogObjectEventName {
         return "View Catalog Object";
       case CatalogObjectEventName.quickView:
         return "Quick View Catalog Object";
-      default:
-        return "";
     }
   }
 }

--- a/lib/inbox_message.dart
+++ b/lib/inbox_message.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'notification_message.dart';
 import 'custom_keys_parser.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
-  provider: ^6.1.2
 
 dev_dependencies:
   flutter_test:

--- a/test/sfmc_method_channel_test.dart
+++ b/test/sfmc_method_channel_test.dart
@@ -62,7 +62,7 @@ void main() {
       deleted: true,
       read: false,
       url: "https://example.com/3",
-      sendDateUtc: DateTime.now().subtract(Duration(days: 2)),
+      sendDateUtc: DateTime.now().subtract(const Duration(days: 2)),
     ).toJson()),
   ];
 

--- a/test/sfmc_test.dart
+++ b/test/sfmc_test.dart
@@ -289,11 +289,7 @@ void main() {
   const String testValue = 'testValue';
   const String testTag = 'testTag';
   const String testContactKey = 'testContactKey';
-  const List<String> testMsg = ['testMsg'];
-  const List<String> testReadMsg = ['testReadMsg'];
-  const List<String> testUnreadMsg = ['testUnreadMsg'];
-  const List<String> testDeletedMsg = ['testDeletedMsg'];
-  String testMessageId = 'messageId';
+  const String testMessageId = 'messageId';
 
   setUp(() {
     mockPlatform = MockSfmcPlatform();
@@ -748,6 +744,26 @@ void main() {
         expect(await SFMCSdk.getDeletedMessageCount(),
             mockPlatform.mockInboxDeletedCount);
         expect(mockPlatform.recentCalledMethod, 'getDeletedMessageCount');
+      });
+
+      test('setMessageRead', () async {
+        await SFMCSdk.setMessageRead(testMessageId);
+        expect(mockPlatform.recentCalledMethod, 'setMessageRead');
+      });
+
+      test('deleteMessage', () async {
+        await SFMCSdk.deleteMessage(testMessageId);
+        expect(mockPlatform.recentCalledMethod, 'deleteMessage');
+      });
+
+      test('markAllMessagesRead', () async {
+        await SFMCSdk.markAllMessagesRead();
+        expect(mockPlatform.recentCalledMethod, 'markAllMessagesRead');
+      });
+
+      test('markAllMessagesDeleted', () async {
+        await SFMCSdk.markAllMessagesDeleted();
+        expect(mockPlatform.recentCalledMethod, 'markAllMessagesDeleted');
       });
 
       test('refreshInbox', () async {


### PR DESCRIPTION
Housekeeping for the plugin package:

- removes the unreachable `default` clauses in events.dart (all three switches cover their enums), an unused import, and unused test variables
- drops `provider` from dependencies - nothing in lib/, test/ or the example references it, and it's currently forced onto every consumer of the plugin
- adds the missing unit tests for `setMessageRead`, `deleteMessage`, `markAllMessagesRead` and `markAllMessagesDeleted`

The two remaining analyzer findings in sfmc_method_channel.dart are left alone on purpose - those exact lines are reworked in #8.
